### PR TITLE
Add Reply-To Header

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -157,6 +157,7 @@ function approve(responseUrl, emailAtt, user) {
     Destination: {
       ToAddresses: sendTo
     },
+    ReplyToAddresses: [tmplContext.author_name],
     Message: {
       Subject: {
         Data: emailAtt.title


### PR DESCRIPTION
As requested by @bradcavanagh – makes it easier for recipients to reply to the person who wrote the letter.