### PR TITLE
Initial refactoring

### DIFF
--- a/athenaStore.js
+++ b/athenaStore.js
@@ -14,7 +14,7 @@ class AthenaLetterStore {
   }
 
   async runQuery(query) {
-    console.log("Running Athena query:", query);
+    console.log('Running Athena query:', query);
     const queryID = uuid.v4();
 
     const startRes = await this.athena.startQueryExecution({
@@ -34,7 +34,7 @@ class AthenaLetterStore {
         QueryExecutionId: startRes.QueryExecutionId,
       }).promise();
 
-      console.log("State is: ", res.QueryExecution.Status.State);
+      console.log('State is: ', res.QueryExecution.Status.State);
       if (['SUCCEEDED', 'FAILED', 'CANCELLED'].includes(res.QueryExecution.Status.State)) {
         break;
       }


### PR DESCRIPTION
Mostly what I've done here is broken `createLetter` down into smaller methods so it's easier to scan and quickly understand. It went from 121 lines to 21. There are also some minor changes to `athenaStore` to cut down on linting errors.

I've run the automated tests and also done an end-to-end test manually once.

Next, I think it's probably worth moving the various Lambda functions into their own files, because `handler.js` is getting a little big. I will do that in a separate PR unless you object.